### PR TITLE
Better query error messages

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -188,7 +188,7 @@ dependencies = [
 
 [[package]]
 name = "cw-unity-prop"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "cosmwasm-schema",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cw-unity-prop"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["Alex Lynham <alex@lynh.am>"]
 edition = "2018"
 

--- a/scripts/build_optimised_release.sh
+++ b/scripts/build_optimised_release.sh
@@ -6,4 +6,4 @@ set -e
 docker run --rm -v "$(pwd)":/code \
   --mount type=volume,source="$(basename "$(pwd)")_cache",target=/code/target \
   --mount type=volume,source=registry_cache,target=/usr/local/cargo/registry \
-  cosmwasm/rust-optimizer:0.12.5
+  cosmwasm/rust-optimizer:0.12.6

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -35,7 +35,7 @@ docker run --rm -d --name $CONTAINER_NAME \
 docker run --rm -v "$(pwd)":/code \
   --mount type=volume,source="$(basename "$(pwd)")_cache",target=/code/target \
   --mount type=volume,source=registry_cache,target=/usr/local/cargo/registry \
-  cosmwasm/rust-optimizer:0.12.5
+  cosmwasm/rust-optimizer:0.12.6
 
 # copy wasm to docker container
 docker cp artifacts/cw_unity_prop.wasm $CONTAINER_NAME:/cw_unity_prop.wasm

--- a/scripts/submit_gov.sh
+++ b/scripts/submit_gov.sh
@@ -35,7 +35,7 @@ docker run --rm -d --name $CONTAINER_NAME \
 docker run --rm -v "$(pwd)":/code \
   --mount type=volume,source="$(basename "$(pwd)")_cache",target=/code/target \
   --mount type=volume,source=registry_cache,target=/usr/local/cargo/registry \
-  cosmwasm/rust-optimizer:0.12.5
+  cosmwasm/rust-optimizer:0.12.6
 
 # copy wasm to docker container
 docker cp artifacts/cw_unity_prop.wasm $CONTAINER_NAME:/cw_unity_prop.wasm


### PR DESCRIPTION
Not essential, but clears up the case where queries fall back to an ugly default CW error if called with no withdraw specified.

- Add explicit error handling for query cases
- Update rust optimizer in CI and scripts